### PR TITLE
feat: create final RS tables and add performance model with docs

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -19,7 +19,8 @@ clean-targets:
 
 models:
   analytics:
-    +schema: analytics_staging   
+    +schema: analytics_staging
     staging:
       +materialized: view
-
+    final:
+      +materialized: table

--- a/models/final/entities/final_aircall_calls.sql
+++ b/models/final/entities/final_aircall_calls.sql
@@ -1,0 +1,32 @@
+
+WITH converted_calls AS (
+    SELECT
+        id,
+        number_id,
+        user_id,
+        raw_digits_anonymized,
+        CONVERT_TIMEZONE('UTC', 'Europe/Madrid', started_at) AS started_at,
+        CONVERT_TIMEZONE('UTC', 'Europe/Madrid', answered_at) AS answered_at,
+        CONVERT_TIMEZONE('UTC', 'Europe/Madrid', ended_at) AS ended_at,
+        duration,
+        missed_call_reason,
+        direction
+    FROM  {{ ref('stg_calls') }}
+)
+
+SELECT
+    *,
+    CASE
+        WHEN answered_at IS NOT NULL THEN TIMESTAMPDIFF(SECOND, started_at, answered_at)
+        ELSE NULL
+    END AS response_time_seconds,
+
+    EXTRACT(HOUR FROM started_at) AS call_hour,
+    DAYOFWEEK(started_at) AS day_of_week,
+    TO_CHAR(started_at, 'DY') AS day_name,
+    CASE
+        WHEN DAYOFWEEK(started_at) IN (1, 7) THEN 'weekend'
+        ELSE 'weekday'
+    END AS day_type
+
+FROM converted_calls

--- a/models/final/entities/final_aircall_calls_rs_extended.sql
+++ b/models/final/entities/final_aircall_calls_rs_extended.sql
@@ -1,0 +1,26 @@
+WITH calls AS (
+    SELECT *
+    FROM {{ ref('final_aircall_calls') }}
+),
+users_rs AS (
+    SELECT *
+    FROM {{ ref('final_aircall_users_rs') }}
+),
+numbers_rs AS (
+    SELECT *
+    FROM {{ ref('final_aircall_numbers_rs') }}
+),
+final AS (
+    SELECT
+        calls.*,
+        users_rs.name AS user_name,
+        numbers_rs.availability_status as number_availability_status,
+        numbers_rs.live_recording_activated,
+        numbers_rs.name AS number_name, 
+        numbers_rs.digits AS number_digits,
+        numbers_rs.is_ivr AS number_is_ivr
+    FROM calls
+    JOIN users_rs ON calls.user_id = users_rs.user_id
+    LEFT JOIN numbers_rs ON calls.number_id = numbers_rs.number_id
+)
+SELECT * FROM final

--- a/models/final/entities/final_aircall_numbers_rs.sql
+++ b/models/final/entities/final_aircall_numbers_rs.sql
@@ -1,0 +1,3 @@
+select *
+from {{ ref('stg_numbers') }}
+WHERE name ILIKE '%RS%'

--- a/models/final/entities/final_aircall_users_rs.sql
+++ b/models/final/entities/final_aircall_users_rs.sql
@@ -1,0 +1,3 @@
+select * 
+from {{ ref('stg_users') }}
+where team = 'RS'

--- a/models/final/metrics/final_aircall_performance_rs.sql
+++ b/models/final/metrics/final_aircall_performance_rs.sql
@@ -1,0 +1,52 @@
+WITH date_series AS (
+    SELECT DISTINCT DATE_TRUNC('day', started_at) AS day
+    FROM {{ ref('final_aircall_calls_rs_extended') }}
+),
+all_agents AS (
+    SELECT DISTINCT user_id, user_name
+    FROM {{ ref('final_aircall_calls_rs_extended') }}
+),
+cross_join_dates_agents AS (
+    SELECT a.user_id, a.user_name, d.day
+    FROM all_agents a
+    CROSS JOIN date_series d
+),
+calls_per_agent AS (
+    SELECT
+        user_id,
+        user_name,
+        DATE_TRUNC('day', started_at) AS day,
+        COUNT(DISTINCT ID) AS total_calls,
+        SUM(duration) AS total_duration_seconds,
+        AVG(duration) AS average_call_duration,
+        COUNT(CASE WHEN duration >= 180 THEN 1 END) AS successful_calls,
+        COUNT(CASE WHEN direction = 'inbound' THEN 1 END) AS inbound_calls,
+        COUNT(CASE WHEN direction = 'outbound' THEN 1 END) AS outbound_calls
+    FROM {{ ref('final_aircall_calls_rs_extended') }}
+    GROUP BY user_id, user_name, DATE_TRUNC('day', started_at)
+)
+
+SELECT
+    c.user_id,
+    c.user_name,
+    c.day,
+    COALESCE(p.total_calls, 0) AS total_calls,
+    COALESCE(p.total_duration_seconds, 0) AS total_duration_seconds,
+    COALESCE(p.average_call_duration, 0) AS average_call_duration,
+    COALESCE(p.successful_calls, 0) AS successful_calls,
+    COALESCE(p.inbound_calls, 0) AS inbound_calls,
+    COALESCE(p.outbound_calls, 0) AS outbound_calls,
+    17 AS target_calls,
+    ROUND(COALESCE(p.outbound_calls, 0) / 17.0, 2) AS target_achievement_ratio,
+    CASE
+        WHEN COALESCE(p.outbound_calls, 0) >= 17 THEN TRUE
+        ELSE FALSE
+    END AS in_target,
+    ROUND(
+        CASE
+            WHEN COALESCE(p.total_calls, 0) > 0 THEN COALESCE(p.successful_calls, 0) * 1.0 / COALESCE(p.total_calls, 1)
+            ELSE 0
+        END,
+    2) AS success_rate
+FROM cross_join_dates_agents c
+LEFT JOIN calls_per_agent p ON c.user_id = p.user_id AND c.day = p.day

--- a/models/final/schema.yml
+++ b/models/final/schema.yml
@@ -1,0 +1,34 @@
+version: 2
+
+models:
+  - name: final_aircall_performance_rs
+    description: >
+      Daily performance metrics per RS team user, including inbound and outbound calls,
+      duration, effectiveness, and achievement of the minimum target of 17 outbound calls per day.
+    columns:
+      - name: user_id
+        description: Unique identifier of the RS team agent.
+      - name: user_name
+        description: Name of the agent.
+      - name: day
+        description: Analysis day (daily aggregation).
+      - name: total_calls
+        description: Total number of calls (inbound + outbound).
+      - name: total_duration_seconds
+        description: Total call duration for the day (in seconds).
+      - name: average_call_duration
+        description: Average duration of calls for the day (in seconds).
+      - name: successful_calls
+        description: Calls considered successful (duration >= 180 seconds).
+      - name: inbound_calls
+        description: Number of inbound calls.
+      - name: outbound_calls
+        description: Number of outbound calls.
+      - name: target_calls
+        description: Expected daily target for outbound calls (fixed at 17).
+      - name: target_achievement_ratio
+        description: Ratio of target fulfillment (outbound_calls / target_calls).
+      - name: in_target
+        description: Boolean flag indicating whether the target was met (TRUE if outbound_calls >= 17).
+      - name: success_rate
+        description: Proportion of successful calls over total calls for the day.

--- a/models/staging/schema.yml
+++ b/models/staging/schema.yml
@@ -56,7 +56,7 @@ models:
   - name: stg_users
     description: Staging table for Aircall users associated with call activity
     columns:
-      - name: id
+      - name: user_id
         description: Unique identifier of the user
       - name: wrap_up_time
         description: Wrap-up time after call in seconds


### PR DESCRIPTION
- Created final tables: final_aircall_calls, final_aircall_users_rs, final_aircall_numbers_rs
- Added final_aircall_performance_rs model with daily metrics by agent
- Documented final_aircall_performance_rs in schema.yml